### PR TITLE
Add Parameter property to Task state

### DIFF
--- a/src/__tests__/definitions/valid-task-parameters.json
+++ b/src/__tests__/definitions/valid-task-parameters.json
@@ -1,0 +1,18 @@
+{
+  "Comment": "https://states-language.net/spec.html#parameters",
+  "StartAt": "X",
+  "States": {
+    "X": {
+      "Type": "Task",
+      "Resource": "arn:aws:swf:us-east-1:123456789012:task:X",
+      "Parameters": {
+        "flagged": true,
+        "parts": {
+          "first.$": "$.vals[0]",
+          "last3.$": "$.vals[3:]"
+        }
+      },
+      "End": true
+    }
+  }
+}

--- a/src/schemas/task.json
+++ b/src/schemas/task.json
@@ -81,6 +81,9 @@
     "HeartbeatSeconds": {
       "type": "number",
       "minimum": 1
+    },
+    "Parameters": {
+      "type": "object"
     }
   },
   "oneOf": [{


### PR DESCRIPTION
The current implementation rejects `Task` states with a `Parameters` property.

c.f. https://states-language.net/spec.html#parameters