### PR TITLE
Fix validation of lambda aliases in task ARNs

### DIFF
--- a/src/__tests__/definitions/invalid-task-alias-function.json
+++ b/src/__tests__/definitions/invalid-task-alias-function.json
@@ -1,0 +1,16 @@
+{
+    "Comment": "An example of the Amazon States Language using an AWS Lambda Function with invalid aliases",
+    "StartAt": "MissingAlias",
+    "States": {
+      "MissingAlias": {
+        "Type": "Task",
+        "Resource": "arn:aws:lambda:region-1:1234567890:function:FUNCTION_NAME:",
+        "Next": "InvalidAlias"
+      },
+      "InvalidAlias": {
+        "Type": "Task",
+        "Resource": "arn:aws:lambda:region-1:1234567890:function:FUNCTION_NAME:$*#$7485",
+        "End": true
+      }
+    }
+  }

--- a/src/__tests__/definitions/valid-task-alias-function.json
+++ b/src/__tests__/definitions/valid-task-alias-function.json
@@ -1,0 +1,16 @@
+{
+  "Comment": "An example of the Amazon States Language using an AWS Lambda Function with aliases",
+  "StartAt": "LatestAlias",
+  "States": {
+    "LatestAlias": {
+      "Type": "Task",
+      "Resource": "arn:aws:lambda:region-1:1234567890:function:FUNCTION_NAME:$LATEST",
+      "Next": "CustomAlias"
+    },
+    "CustomAlias": {
+      "Type": "Task",
+      "Resource": "arn:aws:lambda:region-1:1234567890:function:FUNCTION_NAME:AZaz12-_",
+      "End": true
+    }
+  }
+}

--- a/src/schemas/task.json
+++ b/src/schemas/task.json
@@ -25,7 +25,7 @@
     "Resource": {
       "oneOf": [{
         "type": "string",
-        "pattern": "^arn:aws:([a-z]|-)+:([a-z]|[0-9]|-)*:[0-9]*:([a-z]|-)+:[a-zA-Z0-9-_.]+$"
+        "pattern": "^arn:aws:([a-z]|-)+:([a-z]|[0-9]|-)*:[0-9]*:([a-z]|-)+:[a-zA-Z0-9-_.]+(:(\\$LATEST|[a-zA-Z0-9-_]+))?$"
       }, {
         "type": "object"
       }]


### PR DESCRIPTION
You can specify a specific alias of a function from a step function to
enable the pinning of step function versions to specific versions of
Lambdas. This change adds this syntax to the task ARN regex.

Fixes #38

I've tested this change with the project that exhibited the issue in the first place and it seems to be working well. Let me know if you can think of a test case I've missed.