### PR TITLE
fixing pass state to have parameters property

### DIFF
--- a/src/__tests__/definitions/valid-pass-state.json
+++ b/src/__tests__/definitions/valid-pass-state.json
@@ -1,0 +1,34 @@
+{
+  "Comment": "An example of the Amazon States Language using a pass state.",
+  "StartAt": "FirstState",
+  "States": {
+    "FirstState": {
+      "Type": "Task",
+      "Resource": "arn:aws:lambda:region-1:1234567890:function:FUNCTION_NAME",
+      "ResultPath": "$.fooList",
+      "Next": "ForLoopCondition"
+    },
+    "ForLoopCondition": {
+      "Type": "Choice",
+      "Choices": [{
+          "Not": {
+            "Variable": "$.fooList[0]",
+            "StringEquals": "DONE"
+          },
+          "Next": "PassState"
+        }
+      ],
+      "Default": "Succeed"
+    },
+    "PassState": {
+      "Type": "Pass",
+      "Parameters": {
+        "fooList.$": "$.fooList[1:]"
+      },
+      "Next": "ForLoopCondition"
+    },
+    "Succeed": {
+      "Type": "Succeed"
+    }
+  }
+}

--- a/src/schemas/pass.json
+++ b/src/schemas/pass.json
@@ -25,6 +25,9 @@
     "ResultPath": {
       "type": "string"
     },
+    "Parameters": {
+      "type": "object"
+    },
     "Result": {}
   },
   "oneOf": [{


### PR DESCRIPTION
See [issue 40](https://github.com/airware/asl-validator/issues/40) for context.

@ChristopheBougere - Let me know if I'm interpreted your comment on the issue incorrectly - but I think I made the necessary changes. Let me know if there are any questions or concerns about my proposed changes.

Note: My `valid-pass-state.json` file is just a simplied version of this [sample project](https://docs.aws.amazon.com/step-functions/latest/dg/sample-project-transfer-data-sqs.html#sample-sqs-code-examples)